### PR TITLE
add padding_color parameter (issue #80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ An advanced image conversion server and command line tool.
 	* [Changing Size](#changing-size)
 	* [Area of Interest](#area-of-interest)
 	* [Cropping Mode](#cropping-mode)
+	* [Padding Color](#padding-color)
+	* [Cropping Mode](#cropping-mode)
 	* [Image format](#image-format)
 	* [Quality](#quality)
 	* [Color Palette](#color-palette)
@@ -95,6 +97,15 @@ The `crop` parameter sets the cropping mode. Available modes are:
 Details about the cropping modes can be found [here in the wiki](https://github.com/berlinonline/converjon/wiki/Cropping-Modes). For examples, see the [demo page](http://berlinonline.github.io/converjon/demo/demo.html).
 
 If an AOI is set, cropping will ensure, that the area is always preserved.
+
+### Padding Color
+
+The `padding_color` parameter sets the background color of the padding.
+
+The color should be specified in an HTML URL Encoded format.
+
+If none specified, the default color set in the configuration will be used.
+[see also Converter config](#converter)
 
 ### Image Format
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -47,6 +47,7 @@ function formatCropRect(cropRect) {
  * @return array
  */
 function getConvertArgs(source_path, target_path, options, config) {
+    console.log(options.padding_color);
     var args = [];
     var to = getImageMagickFormat(options.format);
 
@@ -75,7 +76,7 @@ function getConvertArgs(source_path, target_path, options, config) {
     }
 
     if (options.padding) {
-        args.push("-bordercolor", config.converter.padding_color );
+        args.push("-bordercolor", options.padding_color ? options.padding_color : config.converter.padding_color);
         args.push("-border", options.padding.x + "x" + options.padding.y);
     }
 

--- a/lib/processing.js
+++ b/lib/processing.js
@@ -84,6 +84,12 @@ function ConstraintError(option, value, c) {
 }
 ConstraintError.prototype = new Error();
 
+function ColorFormatError(color) {
+    this.message = color+" is not in a valid HTML color format.";
+    this.name = "ColorFormatError";
+}
+ColorFormatError.prototype = new Error();
+
 function check_constraints(item) {
     var constraints = item.conf.constraints;
     var options = item.options;
@@ -109,6 +115,16 @@ function check_constraints(item) {
     }
 }
 
+function check_padding_color(item) {
+    var options = item.options;
+
+    if (options.hasOwnProperty("padding_color")) {
+      if (!/^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/.test(options.padding_color)) {
+        throw new ColorFormatError(options.padding_color);
+      }
+    }
+}
+
 function create_target_file(item) {
     set_default_options(item);
     var promise = new Promise(function(resolve, reject) {
@@ -116,6 +132,7 @@ function create_target_file(item) {
         try {
             add_cropping(item);
             check_constraints(item);
+            check_padding_color(item);
         } catch (err) {
             item.error = err;
             reject(item);
@@ -144,5 +161,6 @@ function create_target_file(item) {
 module.exports = {
     create_target_file: create_target_file,
     set_default_options: set_default_options,
-    check_aoi: check_aoi
+    check_aoi: check_aoi,
+    check_padding_color: check_padding_color
 };

--- a/test/check_padding_color.js
+++ b/test/check_padding_color.js
@@ -1,0 +1,41 @@
+/* jshint globalstrict: true */
+/* global require */
+/* global module */
+"use strict";
+
+var check_padding_color = require("../lib/processing").check_padding_color;
+
+module.exports = {
+
+    testValidColorFormat: function (test) {
+        test.expect(1);
+        var testitem = {
+            options: {
+                padding_color: '#ff0000'
+            }
+        };
+        try {
+            check_padding_color(testitem);
+            test.strictEqual(1, 1);
+        } catch (e) {
+            // should not happen in this test
+        }
+        test.done();
+    },
+
+    testInvalidColorFormat: function (test) {
+        test.expect(1);
+        var testitem = {
+            options: {
+                padding_color: 'nf0000'
+            }
+        };
+        try {
+            check_padding_color(testitem);
+        } catch (e) {
+            test.strictEqual(e.name, "ColorFormatError");
+        }
+        test.done();
+    }
+};
+


### PR DESCRIPTION
* The parameter's format is validated using regexp
* If the parameter is not specified, the color specified in the config will be used as a fallback. 
* A new error ('ColorFormatError') was added
* Two tests were added under test/check_padding_color.js
