### PR TITLE
fixed a bug, where rejectInvalidSSL did not get evaluated correctly, …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ results
 node_modules
 npm-debug.log
 .DS_Store
+.idea
 
 cache
 status.json

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ You can also prefix the pattern with ``~ `` (like ``~ ^http://(foo|bar)\.example
 `download.timeout` sets a timeout after which requests are cancelled, if the source server doesn't respond in time.
 
 **Reject Invalid SSL Certificates**
-Setting `download.rejectInvalidSSL` to `true` will cause sources to be rejected, if their SSL certificates can nnot be validated.
+Setting `download.rejectInvalidSSL` to `true` (default) will cause sources to be rejected, if their SSL certificates can nnot be validated.
 
 ###Aliases
 

--- a/lib/source.js
+++ b/lib/source.js
@@ -96,14 +96,14 @@ function download_source(item) {
             request_options.timeout = conf.download.timeout;
         }
 
-        if (conf.download.rejectInvalidSSL) {
-            request_options.strictSSL = conf.download.rejectInvalidSSL;
-        }
+        request_options.strictSSL = conf.download.rejectInvalidSSL;
 
         logging.debug(id, "Starting request", url);
         response_stream = request.get(url, request_options);
         response_stream.on("error", function(err) {
             var message;
+
+            logging.debug(id, 'Response error: ' + err.message);
 
             switch (err.message) {
                 case "connect ECONNREFUSED":


### PR DESCRIPTION
…so that

invalid SSL connections did not work (e.g. with a self-signed certificate)

added a debug message: when a request error occurs, the error message gets logged