### PR TITLE
Added config option for imagemagick convert filter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -32,7 +32,9 @@ analysis:
   aoi_name: "AOI"
 
 converter:
+  filter: false
   padding_color: "#fefe00"
+  quality: false
 
 cropping:
   default_mode: "aoi_coverage"

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -79,6 +79,10 @@ function getConvertArgs(source_path, target_path, options, config) {
         args.push("-border", options.padding.x + "x" + options.padding.y);
     }
 
+    if (config.converter.filter) {
+        args.push("-filter", config.converter.filter);
+    }
+
     if (options.width && options.height) {
         args.push("-resize", options.width+"x"+options.height+"!");
     } else if (options.width) {
@@ -89,6 +93,8 @@ function getConvertArgs(source_path, target_path, options, config) {
 
     if (options.quality && to == "jpg") {
         args.push("-quality", options.quality+"%");
+    } else if (to == "jpg" && config.converter.quality) {
+        args.push("-quality", config.converter.quality+"%");
     }
 
     if (options.colors && to == "gif") {


### PR DESCRIPTION
Setting a filter to imagemagick convert can  improve image quality. But
sharper images might be bigger in size. So a hard quality settings for
jpegs is added, too.